### PR TITLE
YWGC-8: Add github action to auto-add PR reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,28 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - novellac
+  - ajkarczewski
+  - Dreamy26
+  - alliequintano
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+# A list of assignees, overrides reviewers if set
+# assignees:
+#   - assigneeA
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+# numberOfAssignees: 2
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+# skipKeywords:
+#   - wip

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,10 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.4


### PR DESCRIPTION
## Context

As a part of our initial project setup, we wanted to auto-add reviewers of PRs to improve our workflow. The default list we discussed included @novellac as product owner, @Dreamy26 and @ajkarczewski as devs, and me as PM/reviewer. Although we only require one approval to merge, assigning everyone as a reviewer notifies us and keeps us in the loop.

## Work done

I found a popular github action on github's marketplace and followed their instruction for how to set it up: https://github.com/marketplace/actions/auto-assign-action

## Manual testing instructions

Once I open this PR, we should see if the action executes in the checks list and if the reviewers are added.

## Gotchas/What I learned
trying out the Jira github integration by including the card number in the branch and commit message!