### PR TITLE
YWGC-10: Add jira card link to PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,7 @@
 ## Context
 
+[link to Jira card]
+
 ## Work done
 
 ## Manual testing instructions


### PR DESCRIPTION
## Context

https://ywgc.atlassian.net/browse/YWGC-10
We want to easily link our work to the card in Jira, so we want to make it easy for people to add a link to the card in their PR via the PR template.

## Work done

Added a placeholder line in the template.

## Manual testing instructions

None - once this is merged we should see it in the PR template.

## Gotchas/What I learned