### PR TITLE
bug: service area section goes before the bio section

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,8 @@ export default function App () {
       <div id='services-section'>
         <Services />
       </div>
-      <BioMose />
       <ServiceArea />
+      <BioMose />
       <Footer />
     </div>
   )


### PR DESCRIPTION
## Context
Fix minor bug

https://ywgc.atlassian.net/browse/YWGC-40?atlOrigin=eyJpIjoiMmU0NjVmZmRjMWQ1NGQxYjgyNDQ1YWMzNmVkMzk4YzQiLCJwIjoiaiJ9

## Work done
Make sure the service area section goes before the bio section according to figma design.


## Manual testing instructions
When scrolling down. The page "Areas we serve" should show before "About" page

## Gotchas/What I learned
